### PR TITLE
fix: fix team member stats bug

### DIFF
--- a/race-info-footer.js
+++ b/race-info-footer.js
@@ -125,7 +125,8 @@ const getTeamStats = async () => {
         Authorization: `Bearer ${authToken}`,
       },
     });
-    const { leaderboard, motd, info, stats, members, season } = await response.json();
+    const { results } = await response.json();
+    const { leaderboard, motd, info, stats, members, season } = results
     const member = members?.find((u) => u.userID === CURRENT_USER.userID);
     const seasonStats = season?.find((u) => u.userID === CURRENT_USER.userID);
     return { leaderboard, motd, info, stats, member, season: seasonStats };


### PR DESCRIPTION
This commit fixes a bug that prevented the team and season stats from
showing when a user was in a team.
